### PR TITLE
Fix RPP call when requesting Authenticate data

### DIFF
--- a/app/data-sources/rural-payments/RuralPaymentsCustomer.js
+++ b/app/data-sources/rural-payments/RuralPaymentsCustomer.js
@@ -1,3 +1,4 @@
+import { NotFound } from '../../errors/graphql.js'
 import { logger, sampleResponse } from '../../utils/logger.js'
 import { RuralPayments } from './RuralPayments.js'
 
@@ -22,7 +23,12 @@ export class RuralPaymentsCustomer extends RuralPayments {
       const response = customerResponse._data.pop() || {}
       logger.debug('Customer by CRN', { response: sampleResponse(response) })
 
-      return response?.id ? this.getPersonByPersonId(response.id) : null
+      if (!response?.id) {
+        logger.info(`Customer not found for CRN: ${crn}`)
+        throw new NotFound('Customer not found')
+      }
+
+      return this.getPersonByPersonId(response.id)
     } catch (error) {
       logger.error('Error getting customer by CRN', { crn, error })
       throw error

--- a/app/graphql/resolvers/customer/customer.js
+++ b/app/graphql/resolvers/customer/customer.js
@@ -10,6 +10,13 @@ import {
 import { logger } from '../../../utils/logger.js'
 
 export const Customer = {
+  async personId ({ crn }, __, { dataSources }) {
+    const { id: personId } =
+      await dataSources.ruralPaymentsCustomer.getCustomerByCRN(crn)
+    logger.debug('Get customer id from crn', { crn, personId })
+    return personId
+  },
+
   async info ({ crn }, __, { dataSources }) {
     const response = await dataSources.ruralPaymentsCustomer.getCustomerByCRN(
       crn
@@ -17,7 +24,9 @@ export const Customer = {
     return ruralPaymentsPortalCustomerTransformer(response)
   },
 
-  async business ({ crn, personId }, { sbi }, { dataSources }) {
+  async business ({ crn }, { sbi }, { dataSources }) {
+    const { id: personId } = await dataSources.ruralPaymentsCustomer.getCustomerByCRN(crn)
+
     const summary = await dataSources.ruralPaymentsCustomer.getPersonBusinessesByPersonId(
       personId,
       sbi
@@ -30,7 +39,9 @@ export const Customer = {
     )
   },
 
-  async businesses ({ crn, personId }, __, { dataSources }) {
+  async businesses ({ crn }, __, { dataSources }) {
+    const { id: personId } = await dataSources.ruralPaymentsCustomer.getCustomerByCRN(crn)
+
     const summary = await dataSources.ruralPaymentsCustomer.getPersonBusinessesByPersonId(
       personId
     )

--- a/app/graphql/resolvers/customer/query.js
+++ b/app/graphql/resolvers/customer/query.js
@@ -1,18 +1,5 @@
-import { NotFound } from '../../../errors/graphql.js'
-import { logger } from '../../../utils/logger.js'
-
 export const Query = {
-  async customer (__, { crn }, { dataSources }) {
-    const response = await dataSources.ruralPaymentsCustomer.getCustomerByCRN(crn)
-
-    if (!response) {
-      logger.info(`Customer not found for CRN: ${crn}`)
-      throw new NotFound('Customer not found')
-    }
-
-    return {
-      crn,
-      personId: response.id
-    }
+  async customer (__, { crn }) {
+    return { crn }
   }
 }

--- a/mocks/fixtures/personId/5263421/organisationSummary.json
+++ b/mocks/fixtures/personId/5263421/organisationSummary.json
@@ -1,7 +1,7 @@
 {
   "_data": [
     {
-      "id": 5263421,
+      "id": 5565448,
       "name": "HENLEY, RE",
       "sbi": 107183280,
       "additionalSbiIds": [],

--- a/mocks/fixtures/personId/5311964/organisationSummary.json
+++ b/mocks/fixtures/personId/5311964/organisationSummary.json
@@ -1,7 +1,7 @@
 {
   "_data": [
     {
-      "id": 5311964,
+      "id": 5565448,
       "name": "HENLEY, RE",
       "sbi": 107183280,
       "additionalSbiIds": [],

--- a/mocks/fixtures/personId/5331098/organisationSummary.json
+++ b/mocks/fixtures/personId/5331098/organisationSummary.json
@@ -1,7 +1,7 @@
 {
   "_data": [
     {
-      "id": 5331098,
+      "id": 5565448,
       "name": "HENLEY, RE",
       "sbi": 107183280,
       "additionalSbiIds": [],

--- a/mocks/fixtures/personId/5778203/organisationSummary.json
+++ b/mocks/fixtures/personId/5778203/organisationSummary.json
@@ -1,7 +1,7 @@
 {
   "_data": [
     {
-      "id": 5778203,
+      "id": 5565448,
       "name": "HENLEY, RE",
       "sbi": 107183280,
       "additionalSbiIds": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-data-access-layer-api",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-data-access-layer-api",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-data-access-layer-api",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/test/integration/graphql/customer.test.js
+++ b/test/integration/graphql/customer.test.js
@@ -2,13 +2,13 @@ import { DefaultAzureCredential } from '@azure/identity'
 import { graphql, GraphQLError } from 'graphql'
 
 import { EntraIdApi } from '../../../app/data-sources/entra-id/EntraIdApi.js'
-import { fakeContext } from '../../test-setup.js'
 import { NotFound } from '../../../app/errors/graphql.js'
-import { personById } from '../../../mocks/fixtures/person.js'
-import { ruralPaymentsPortalCustomerTransformer } from '../../../app/transformers/rural-payments/customer.js'
 import { schema } from '../../../app/graphql/server.js'
 import { transformAuthenticateQuestionsAnswers } from '../../../app/transformers/authenticate/question-answers.js'
+import { ruralPaymentsPortalCustomerTransformer } from '../../../app/transformers/rural-payments/customer.js'
+import { personById } from '../../../mocks/fixtures/person.js'
 import mockServer from '../../../mocks/server'
+import { fakeContext } from '../../test-setup.js'
 
 const personFixture = personById({ id: '5007136' })
 
@@ -484,7 +484,9 @@ describe('Query.customer.businesses.messages', () => {
 
     expect(result).toEqual({
       data: {
-        customer: null
+        customer: {
+          businesses: null
+        }
       },
       errors: [
         new NotFound('Customer not found')

--- a/test/resolvers/customer.test.js
+++ b/test/resolvers/customer.test.js
@@ -125,7 +125,7 @@ describe('Customer', () => {
         name: 'Cliff Spence T/As Abbey Farm',
         sbi: 107591843,
         organisationId: '5625145',
-        personId: '5007136',
+        personId: 5007136,
         crn: undefined
       }
     ])


### PR DESCRIPTION
Remove global RPP CRN check, only check on attributes that call RPP do not call RPP when only accessing attributes from authenticate service