### PR TITLE
DevEx: pre-commit lint/format checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,6 @@
+
+[ ${STRICT_DEV_MODE} ] || exit 0 # developer opt-in
+
 set +e
 
 changes=$( git diff --cached --name-only --diff-filter=ACMR )

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,23 @@
+set +e
+
+changes=$( git diff --cached --name-only --diff-filter=ACMR )
+gqlChanges=$( echo ${changes} | tr ' ' '\n' | grep "app/graphql/types/.*.gql" )
+jsChanges=$( echo ${changes} | tr ' ' '\n' | grep ".*.js$" )
+errors=0
+
+if [ -n "${gqlChanges}" ] ; then
+    npx eslint ${gqlChanges}
+    errors=$?
+    npx prettier --check ${gqlChanges}
+    errors=$(( ${errors} + $? ))
+fi
+[ -z "${jsChanges}" ] || npx standard ${jsChanges}
+errors=$(( ${errors} + $? ))
+
+if [ ${errors} -gt 0 ] ; then
+    echo "\n\033[31mERROR\033[0m: linting or formatting errors were detected!
+Try auto fixing with:
+
+    \033[34mnpm run format\033[0m\n"
+    exit 1
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@mocks-server/core": "^4.0.2",
         "dotenv": "^16.3.1",
         "eslint": "^8.52.0",
+        "husky": "^9.1.6",
         "jest": "^29.6.4",
         "jest-junit": "^16.0.0",
         "mock-jwks": "^3.2.2",
@@ -7668,6 +7669,22 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-data-access-layer-api",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:integration": "NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern=test/integration  --setupFiles dotenv/config",
     "test:local": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --setupFiles dotenv/config",
     "test:unit": "NODE_OPTIONS=--experimental-vm-modules DOTENV_CONFIG_PATH=./.env.test jest --runInBand --coverage --setupFiles dotenv/config",
-    "test:changedsince": "NODE_OPTIONS=--experimental-vm-modules DOTENV_CONFIG_PATH=./.env.test jest --runInBand --changedSince=main --coverage --onlyChanged --setupFiles dotenv/config"
+    "test:changedsince": "NODE_OPTIONS=--experimental-vm-modules DOTENV_CONFIG_PATH=./.env.test jest --runInBand --changedSince=main --coverage --onlyChanged --setupFiles dotenv/config",
+    "prepare": "[ ${CI} ] || husky"
   },
   "author": "Defra",
   "contributors": [],
@@ -56,6 +57,7 @@
     "@mocks-server/core": "^4.0.2",
     "dotenv": "^16.3.1",
     "eslint": "^8.52.0",
+    "husky": "^9.1.6",
     "jest": "^29.6.4",
     "jest-junit": "^16.0.0",
     "mock-jwks": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "app/index.js",
   "type": "module",
   "scripts": {
-    "format:gql": "prettier \"app/graphql/types/**/*.gql\" --write",
+    "format:gql": "prettier \"app/graphql/types/**/*.gql\" --write --log-level warn",
     "format:js": "standard --fix",
     "format": "npm run format:js && npm run format:gql",
     "lint:gql": "eslint \"app/graphql/types\" && prettier \"app/graphql/types/**/*.gql\" --check",


### PR DESCRIPTION
Prevents code that doesn't meet the project's linting and formatting expectations from being committed.
Prints the results of the checks form part of the command line logs, and a helpful error message with a fix suggestion.