### PR TITLE
add excludeFromList directive

### DIFF
--- a/app/graphql/directives/excludeFromListTransformer.js
+++ b/app/graphql/directives/excludeFromListTransformer.js
@@ -1,0 +1,40 @@
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils'
+import { getNamedType, GraphQLList, GraphQLObjectType } from 'graphql'
+
+export function excludeFromListTransformer(schema) {
+  const schemaWithPartialTypes = mapSchema(schema, {
+    [MapperKind.OBJECT_TYPE](objectConfig) {
+      const type = objectConfig.toConfig()
+      const excludedFields = []
+
+      Object.keys(type.fields).map((key) => {
+        if (getDirective(schema, type.fields[key], 'excludeFromList')) {
+          excludedFields.push(key)
+          delete type.fields[key]
+        }
+      })
+
+      if (excludedFields.length) {
+        type.name = `${objectConfig.name}Partial`
+        type.description = `${type.description}\n\nPartial of type \`${objectConfig.name}\` with excluded fields: ${excludedFields.join(', ')}`
+        return new GraphQLObjectType(type)
+      }
+
+      return objectConfig
+    }
+  })
+
+  return mapSchema(schema, {
+    [MapperKind.FIELD](fieldConfig) {
+      if (fieldConfig.type instanceof GraphQLList) {
+        const type = getNamedType(fieldConfig.type)
+        const summaryType = schemaWithPartialTypes.getType(`${type.name}Partial`)
+
+        if (summaryType) {
+          fieldConfig.type = new GraphQLList(summaryType)
+        }
+      }
+      return fieldConfig
+    }
+  })
+}

--- a/app/graphql/directives/onDirectiveTransformer.js
+++ b/app/graphql/directives/onDirectiveTransformer.js
@@ -1,0 +1,9 @@
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils'
+
+export function onDirectiveTransformer(schema) {
+  return (schema = mapSchema(schema, {
+    [MapperKind.FIELD](fieldConfig) {
+      return getDirective(schema, fieldConfig, 'on')?.[0] ? fieldConfig : null
+    }
+  }))
+}

--- a/app/graphql/resolvers/business/business.js
+++ b/app/graphql/resolvers/business/business.js
@@ -16,7 +16,7 @@ export const Business = {
     return { organisationId }
   },
 
-  async cphList({ organisationId }, _, { dataSources }) {
+  async cphs({ organisationId }, _, { dataSources }) {
     return transformOrganisationCPH(
       organisationId,
       await dataSources.ruralPaymentsBusiness.getOrganisationCPHCollectionByOrganisationId(

--- a/app/graphql/schema.js
+++ b/app/graphql/schema.js
@@ -1,18 +1,12 @@
+import { loadFiles } from '@graphql-tools/load-files'
+import { mergeResolvers } from '@graphql-tools/merge'
+import { makeExecutableSchema } from '@graphql-tools/schema'
+import { filterSchema, pruneSchema } from '@graphql-tools/utils'
 import { dirname, join } from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
-
-import { loadFiles } from '@graphql-tools/load-files'
-import { makeExecutableSchema } from '@graphql-tools/schema'
-import { mergeResolvers } from '@graphql-tools/merge'
-import {
-  MapperKind,
-  filterSchema,
-  getDirective,
-  mapSchema,
-  pruneSchema
-} from '@graphql-tools/utils'
-
 import { authDirectiveTransformer } from '../auth/authenticate.js'
+import { excludeFromListTransformer } from './directives/excludeFromListTransformer.js'
+import { onDirectiveTransformer } from './directives/onDirectiveTransformer.js'
 
 async function getFiles(path) {
   return loadFiles(join(dirname(fileURLToPath(import.meta.url)), path), {
@@ -26,26 +20,20 @@ export async function createSchema() {
     typeDefs: await getFiles('types'),
     resolvers: mergeResolvers(await getFiles('resolvers'))
   })
+
   if (!process.env.ALL_SCHEMA_ON) {
-    schema = mapSchema(schema, {
-      [MapperKind.FIELD](fieldConfig) {
-        return getDirective(schema, fieldConfig, 'on')?.[0] ? fieldConfig : null
-      }
-    })
+    schema = onDirectiveTransformer(schema)
   }
 
   if (!process.env.DISABLE_AUTH) {
     schema = authDirectiveTransformer(schema)
   }
 
-  schema = pruneSchema(schema)
+  schema = excludeFromListTransformer(schema)
 
-  schema = filterSchema({
-    schema,
-    directiveFilter(directiveName) {
-      return directiveName !== 'on'
-    }
-  })
+  schema = filterSchema({ schema, directiveFilter: () => false })
+
+  schema = pruneSchema(schema)
 
   return schema
 }

--- a/app/graphql/types/business/business.gql
+++ b/app/graphql/types/business/business.gql
@@ -194,7 +194,7 @@ type Business {
   """
   The CPH (County Parish Holding) numbers of the business.
   """
-  cphList: [CPHSummary]
+  cphs: [CPH]
 
   """
   The CPH (County Parish Holding) numbers of the business.

--- a/app/graphql/types/business/cph.gql
+++ b/app/graphql/types/business/cph.gql
@@ -18,23 +18,6 @@ Represents a County Parish Holding (CPH) number.
 
 Data Source: Rural Payments Portal (PRR)
 """
-type CPHSummary {
-  """
-  The CPH number, example: "10/327/0023"
-  """
-  number: String
-
-  """
-  The parcel numbers associated with the CPH number.
-  """
-  parcelNumbers: [String]
-}
-
-"""
-Represents a County Parish Holding (CPH) number.
-
-Data Source: Rural Payments Portal (PRR)
-"""
 type CPH {
   """
   The CPH number, example: "10/327/0023"
@@ -49,25 +32,25 @@ type CPH {
   """
   The parish associated with the CPH number.
   """
-  parish: String
+  parish: String @excludeFromList
 
   """
   The start date of the CPH number.
   """
-  startDate: Date
+  startDate: Date @excludeFromList
 
   """
   The expiry date of the CPH number.
   """
-  expiryDate: Date
+  expiryDate: Date @excludeFromList
 
   """
   The species associated with the CPH number.
   """
-  species: [String]
+  species: [String] @excludeFromList
 
   """
   The coordinate of the CPH number.
   """
-  coordinate: CPHCoordinate
+  coordinate: CPHCoordinate @excludeFromList
 }

--- a/app/graphql/types/directives.gql
+++ b/app/graphql/types/directives.gql
@@ -1,2 +1,3 @@
 directive @on on FIELD_DEFINITION
 directive @auth(requires: AuthRole = ADMIN) on OBJECT | FIELD_DEFINITION
+directive @excludeFromList on FIELD_DEFINITION

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-data-access-layer-api",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-data-access-layer-api",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@apollo/datasource-rest": "^6.2.2",
@@ -22,7 +22,7 @@
         "@hapi/hapi": "^21.3.2",
         "applicationinsights": "^2.8.0",
         "fast-redact": "^3.5.0",
-        "graphql": "^16.8.1",
+        "graphql": "^16.9.0",
         "http-status-codes": "^2.3.0",
         "https-proxy-agent": "^7.0.2",
         "jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-data-access-layer-api",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "Customer Registry GraphQL Service",
   "homepage": "https://github.com/DEFRA/fcp-data-access-layer-api",
   "main": "app/index.js",
@@ -37,7 +37,7 @@
     "@hapi/hapi": "^21.3.2",
     "applicationinsights": "^2.8.0",
     "fast-redact": "^3.5.0",
-    "graphql": "^16.8.1",
+    "graphql": "^16.9.0",
     "http-status-codes": "^2.3.0",
     "https-proxy-agent": "^7.0.2",
     "jsonwebtoken": "^9.0.2",

--- a/test/unit/directives/excludeFromListTransformer.test.js
+++ b/test/unit/directives/excludeFromListTransformer.test.js
@@ -1,0 +1,72 @@
+import { buildSchema, findBreakingChanges } from 'graphql'
+import { excludeFromListTransformer } from '../../../app/graphql/directives/excludeFromListTransformer.js'
+
+describe('excludeFromListTransformer', () => {
+  test('should not change schema if directive not used', () => {
+    const oldSchema = buildSchema(`#graphql
+        directive @excludeFromList on FIELD_DEFINITION
+
+        type Thing {
+            id: ID!
+            one: String
+            two: String
+        }
+    
+        type Query {
+            things: [Thing]
+        }
+    `)
+
+    const newSchema = excludeFromListTransformer(oldSchema)
+    const changes = findBreakingChanges(oldSchema, newSchema)
+
+    expect(changes).toEqual([])
+  })
+
+  test('should create partial type with fields excluded', () => {
+    const oldSchema = buildSchema(`#graphql
+        directive @excludeFromList on FIELD_DEFINITION
+
+        type Thing {
+            id: ID!
+            one: String
+            two: String @excludeFromList
+        }
+    
+        type Query {
+            things: [Thing]
+        }
+    `)
+
+    const newSchema = excludeFromListTransformer(oldSchema)
+    const fields = Object.keys(newSchema.getType('ThingPartial').getFields())
+
+    expect(fields).toEqual(['id', 'one'])
+  })
+
+  test('should use partial type when used in a list', () => {
+    const oldSchema = buildSchema(`#graphql
+        directive @excludeFromList on FIELD_DEFINITION
+
+        type Thing {
+            id: ID!
+            one: String
+            two: String @excludeFromList
+        }
+    
+        type Query {
+            things: [Thing]
+        }
+    `)
+
+    const newSchema = excludeFromListTransformer(oldSchema)
+    const changes = findBreakingChanges(oldSchema, newSchema)
+
+    expect(changes).toEqual([
+      {
+        type: 'FIELD_CHANGED_KIND',
+        description: 'Query.things changed type from [Thing] to [ThingPartial].'
+      }
+    ])
+  })
+})

--- a/test/unit/integration/graphql/business.test.js
+++ b/test/unit/integration/graphql/business.test.js
@@ -3,6 +3,10 @@ import { Permissions } from '../../../../app/data-sources/static/permissions.js'
 import { NotFound } from '../../../../app/errors/graphql.js'
 import { schema } from '../../../../app/graphql/server.js'
 import {
+  transformCPHInfo,
+  transformOrganisationCPH
+} from '../../../../app/transformers/rural-payments/business-cph.js'
+import {
   transformBusinessCustomerPrivilegesToPermissionGroups,
   transformOrganisationToBusiness
 } from '../../../../app/transformers/rural-payments/business.js'
@@ -16,16 +20,12 @@ import {
   organisationCPH,
   organisationCPHInfo
 } from '../../../../mocks/fixtures/organisation-cph.js'
-import mockServer from '../../../../mocks/server'
-import { fakeContext } from '../../../test-setup.js'
-import {
-  transformCPHInfo,
-  transformOrganisationCPH
-} from '../../../../app/transformers/rural-payments/business-cph.js'
 import {
   organisationByOrgId,
   organisationPeopleByOrgId
 } from '../../../../mocks/fixtures/organisation.js'
+import mockServer from '../../../../mocks/server'
+import { fakeContext } from '../../../test-setup.js'
 
 const organisationFixture = organisationByOrgId('5565448')._data
 const organisationCPHInfoFixture = organisationCPHInfo('5565448').data
@@ -446,13 +446,13 @@ describe('Query.business.land', () => {
   })
 })
 
-describe('Query.business.cphList', () => {
-  it('cphList', async () => {
+describe('Query.business.cphs', () => {
+  it('cphs', async () => {
     const result = await graphql({
       source: `#graphql
-        query BusinessCPHList {
+        query BusinessCPHs {
           business(sbi: "107183280") {
-            cphList {
+            cphs {
               number
               parcelNumbers
             }
@@ -463,7 +463,7 @@ describe('Query.business.cphList', () => {
       contextValue: fakeContext
     })
 
-    expect(result.data.business.cphList).toEqual(
+    expect(result.data.business.cphs).toEqual(
       transformOrganisationCPH('5565448', organisationCPHFixture)
     )
   })

--- a/test/unit/integration/graphql/full-schema.gql
+++ b/test/unit/integration/graphql/full-schema.gql
@@ -329,7 +329,7 @@ type Business {
   """
   The CPH (County Parish Holding) numbers of the business.
   """
-  cphList: [CPHSummary]
+  cphs: [CPHPartial]
 
   """
   The CPH (County Parish Holding) numbers of the business.
@@ -367,7 +367,7 @@ Represents a County Parish Holding (CPH) number.
 
 Data Source: Rural Payments Portal (PRR)
 """
-type CPHSummary {
+type CPHPartial {
   """
   The CPH number.
   """

--- a/test/unit/resolvers/business.test.js
+++ b/test/unit/resolvers/business.test.js
@@ -51,7 +51,7 @@ describe('Business', () => {
   it('cph', async () => {
     const cph = organisationCPH('5565448').data
     const transformed = transformOrganisationCPH(mockBusiness.organisationId, cph)
-    expect(await Business.cphList(mockBusiness, null, { dataSources })).toEqual(transformed)
+    expect(await Business.cphs(mockBusiness, null, { dataSources })).toEqual(transformed)
   })
 
   it('customers', async () => {


### PR DESCRIPTION
Directive to automatically create a separate type from when an object is used in a list:
```graphql
type CPH {
  number: String
  parcelNumbers: [String]
  parish: String @excludeFromList
  startDate: Date @excludeFromList
  expiryDate: Date @excludeFromList
  species: [String] @excludeFromList
  coordinate: CPHCoordinate @excludeFromList
}

```

Whenever the type is then used as part of a list, the fields that have been excluded are not part of that type:

```graphql
query ExampleQuery($sbi: ID!, $number: String!) {
  business(sbi: $sbi) {
    cphs {
      # fields that were excluded aren't allowed
      number
      parcelNumbers
    }

    cph(number: $number) {
      # all fields allowed
      number
      parcelNumbers
      parish
      startDate
      expiryDate
      species
      coordinate {
        x
        y
      }
    }
  }
}
```