### PR TITLE
Fix land total area to include all parcel types

### DIFF
--- a/app/graphql/resolvers/business/business-land.js
+++ b/app/graphql/resolvers/business/business-land.js
@@ -100,7 +100,7 @@ export const BusinessLandSummary = {
 
   async totalArea({ organisationId, date = new Date() }, __, { dataSources }) {
     return transformTotalArea(
-      await dataSources.ruralPaymentsBusiness.getCoversSummaryByOrganisationIdAndDate(
+      await dataSources.ruralPaymentsBusiness.getParcelsByOrganisationIdAndDate(
         organisationId,
         date
       )

--- a/app/transformers/rural-payments/lms.js
+++ b/app/transformers/rural-payments/lms.js
@@ -10,7 +10,7 @@ export function transformLandCovers(landCover) {
         id,
         code,
         area: convertSquareMetersToHectares(area),
-        name: name.toUpperCase().split(' ').join('_'),
+        name: name,
         isBpsEligible: isBpsEligible === 'true'
       }
     })

--- a/test/unit/integration/graphql/business.test.js
+++ b/test/unit/integration/graphql/business.test.js
@@ -206,7 +206,7 @@ describe('Query.business.land', () => {
                 'Permanent Grassland',
                 coversSummaryData
               ),
-              totalArea: 765.8304,
+              totalArea: 821.1645,
               totalParcels: 302
             }
           }

--- a/test/unit/resolvers/business-land.test.js
+++ b/test/unit/resolvers/business-land.test.js
@@ -104,7 +104,7 @@ describe('BusinessLand', () => {
         { dataSources }
       )
     ).toEqual([
-      { id: '11033654', area: 0.1, name: 'MOCK_NAME', code: 'someCode', isBpsEligible: true }
+      { id: '11033654', area: 0.1, name: 'Mock Name', code: 'someCode', isBpsEligible: true }
     ])
   })
 })

--- a/test/unit/resolvers/business-land.test.js
+++ b/test/unit/resolvers/business-land.test.js
@@ -123,7 +123,7 @@ describe('BusinessLandSummary', () => {
       await BusinessLandSummary.totalArea({ id: 'mockId' }, null, {
         dataSources
       })
-    ).toEqual(0.6)
+    ).toEqual(0.1)
   })
 
   it('arableLandArea', async () => {

--- a/test/unit/transformers/rural-payments-portal/lms.test.js
+++ b/test/unit/transformers/rural-payments-portal/lms.test.js
@@ -24,7 +24,7 @@ describe('LMS transformer', () => {
       ]
     }
     const output = [
-      { area: 0.1, id: 'mockId', name: 'MOCK_NAME', code: 'mockId', isBpsEligible: true }
+      { area: 0.1, id: 'mockId', name: 'Mock Name', code: 'mockId', isBpsEligible: true }
     ]
     expect(transformLandCovers(input)).toEqual(output)
   })


### PR DESCRIPTION
Fix bug where total land area was only including three types of parcel type.

This fix gets all parcels and totals them up.

Do not transform land cover names