### PR TITLE
feat: describe permissions

### DIFF
--- a/app/data-sources/static/permission-groups.json
+++ b/app/data-sources/static/permission-groups.json
@@ -16,7 +16,9 @@
       {
         "level": "AMEND",
         "functions": [
-          "All permissions in View BPS",
+          "View business summary",
+          "View claims",
+          "View land, features and covers",
           "Create and edit a claim",
           "Amend a previously submitted claim",
           "Amend land, features and covers"
@@ -26,7 +28,12 @@
       {
         "level": "SUBMIT",
         "functions": [
-          "All permissions in Amend BPS",
+          "View business summary",
+          "View claims",
+          "View land, features and covers",
+          "Create and edit a claim",
+          "Amend a previously submitted claim",
+          "Amend land, features and covers",
           "Submit a claim",
           "Withdraw a claim",
           "Receive warnings and notifications"
@@ -52,7 +59,8 @@
       {
         "level": "AMEND",
         "functions": [
-          "All permissions in View Business Details",
+          "View business details",
+          "View people associated with the business",
           "Amend business and correspondence contact details"
         ],
         "privilegeNames": ["Amend - business"]
@@ -60,7 +68,9 @@
       {
         "level": "MAKE_LEGAL_CHANGES",
         "functions": [
-          "All permissions in Amend Business Details",
+          "View business details",
+          "View people associated with the business",
+          "Amend business and correspondence contact details",
           "Amend controlled information, such as business name",
           "Confirm business details",
           "Amend bank account details",
@@ -71,7 +81,13 @@
       {
         "level": "FULL_PERMISSION",
         "functions": [
-          "All permissions in Make Legal Changes Business Details",
+          "View business details",
+          "View people associated with the business",
+          "Amend business and correspondence contact details",
+          "Amend controlled information, such as business name",
+          "Confirm business details",
+          "Amend bank account details",
+          "Make young/new farmer declaration",
           "Add someone to the business",
           "Give permissions on business"
         ],
@@ -102,7 +118,11 @@
       {
         "level": "AMEND",
         "functions": [
-          "All permissions in View CS Agreements",
+          "View CS Agreements",
+          "View Land, Features and Cover",
+          "View CS Agreement amendments",
+          "View CS agreement Transfers",
+          "View CS Claims",
           "Amend land, Features and Covers",
           "Create and edit a CS claim",
           "Amend a previously submitted claim",
@@ -116,7 +136,18 @@
       {
         "level": "SUBMIT",
         "functions": [
-          "All permissions in Amend CS agreements",
+          "View CS Agreements",
+          "View Land, Features and Cover",
+          "View CS Agreement amendments",
+          "View CS agreement Transfers",
+          "View CS Claims",
+          "Amend land, Features and Covers",
+          "Create and edit a CS claim",
+          "Amend a previously submitted claim",
+          "Create and edit a CS agreement Amendment",
+          "Revise a previously submitted agreement amendment",
+          "Create and Edit a CS agreement transfer",
+          "Revise a previously submitted agreement transfer",
           "Submit Acceptance of CS Agreement offer",
           "Submit rejection of CS agreement offer",
           "Submit (and resubmit) a CS claim",
@@ -153,7 +184,10 @@
       {
         "level": "AMEND",
         "functions": [
-          "All permissions in View CS Applications",
+          "View CS Scheme eligibility",
+          "View Applications",
+          "View land, features and covers",
+          "View CS agreement offer",
           "View draft CS Agreements",
           "Create and edit a CS application",
           "Amend a previously submitted CS application",
@@ -164,7 +198,14 @@
       {
         "level": "SUBMIT",
         "functions": [
-          "All permissions in Amend CS permissions",
+          "View CS Scheme eligibility",
+          "View Applications",
+          "View land, features and covers",
+          "View CS agreement offer",
+          "View draft CS Agreements",
+          "Create and edit a CS application",
+          "Amend a previously submitted CS application",
+          "Amend Land, Features and Covers",
           "Submit CS Application",
           "Withdraw CS application",
           "Receive warnings and notifications"
@@ -216,7 +257,10 @@
       {
         "level": "AMEND",
         "functions": [
-          "All permissions in View Environmental Land Management",
+          "View Environmental Land Management scheme eligibility",
+          "View Environmental Land Management applications",
+          "View land, features and covers",
+          "View Environmental Land Management agreement offer",
           "View Environmental Land Management agreements",
           "Create and edit a Environmental Land Management application",
           "Amend (but not resubmit) a previously submitted Environmental Land Management application",
@@ -227,7 +271,14 @@
       {
         "level": "SUBMIT",
         "functions": [
-          "All permissions in Amend Environmental Land Management",
+          "View Environmental Land Management scheme eligibility",
+          "View Environmental Land Management applications",
+          "View land, features and covers",
+          "View Environmental Land Management agreement offer",
+          "View Environmental Land Management agreements",
+          "Create and edit a Environmental Land Management application",
+          "Amend (but not resubmit) a previously submitted Environmental Land Management application",
+          "Amend land, features and covers",
           "Submit Environmental Land Management application",
           "Withdraw Environmental Land Management application",
           "Submit acceptance of Environmental Land Management agreement offer",

--- a/app/graphql/types/permissions/permissions.gql
+++ b/app/graphql/types/permissions/permissions.gql
@@ -27,6 +27,11 @@ type ActivePermissionGroup {
   The permission level customer has for the business.
   """
   level: PermissionLevel @on
+
+  """
+  The functions that can be performed with given permission level.
+  """
+  functions: [String] @on
 }
 
 type PermissionGroup {

--- a/app/transformers/rural-payments/business.js
+++ b/app/transformers/rural-payments/business.js
@@ -29,7 +29,8 @@ export function transformBusinessCustomerPrivilegesToPermissionGroups(
       if (permission.privilegeNames.some((privilegeName) => privileges.includes(privilegeName))) {
         customerPermissionGroups.push({
           id: permissionGroup.id,
-          level: permission.level
+          level: permission.level,
+          functions: permission.functions
         })
       }
     }

--- a/app/transformers/rural-payments/customer.js
+++ b/app/transformers/rural-payments/customer.js
@@ -23,22 +23,23 @@ export function transformBusinessCustomerToCustomerPermissionGroups(
   if (!customerPrivileges) {
     return permissionGroups.map(({ id, permissions }) => ({
       id,
-      level: permissions[0].level
+      level: permissions[0].level,
+      functions: permissions[0].functions
     }))
   }
 
-  return permissionGroups.map(({ id, permissions }) => ({
-    id,
-    level: permissions.reduce(
-      (level, permission) =>
-        permission.privilegeNames.some((privilegeName) =>
+  return permissionGroups.map(({ id, permissions }) => {
+    const customerPermisson = permissions.reduce(
+      (permission, currentPermission) =>
+        currentPermission.privilegeNames.some((privilegeName) =>
           customerPrivileges.includes(privilegeName.toLowerCase())
         )
-          ? permission.level
-          : level,
-      permissions[0].level
+          ? currentPermission
+          : permission,
+      permissions[0]
     )
-  }))
+    return { id, level: customerPermisson.level, functions: customerPermisson.functions }
+  })
 }
 
 export function transformPersonSummaryToCustomerAuthorisedBusinesses(properties, summary) {

--- a/app/transformers/rural-payments/permissions.js
+++ b/app/transformers/rural-payments/permissions.js
@@ -20,18 +20,3 @@ export function transformOrganisationAuthorisationToCustomerBusinessPermissionLe
 
   return null
 }
-
-export function transformPrivilegesListToBusinessCustomerPermissions(privileges, permissionGroups) {
-  return permissionGroups.map((permissionGroup) => {
-    permissionGroup.permissions.reverse()
-
-    return {
-      id: permissionGroup.id,
-      name: permissionGroup.name,
-      level:
-        permissionGroup.permissions.find(({ privilegeNames }) =>
-          privilegeNames.some((privilege) => privileges.includes(privilege))
-        )?.level || 'NO_ACCESS'
-    }
-  })
-}

--- a/test/test-helpers/permissions.js
+++ b/test/test-helpers/permissions.js
@@ -1,0 +1,14 @@
+import { Permissions } from '../../app/data-sources/static/permissions.js'
+
+const permissionGroups = new Permissions().getPermissionGroups()
+
+export const getPermissionFunctionsFromIdAndLevel = ({ id, level }) => ({
+  id,
+  level,
+  functions: permissionGroups
+    .find((group) => group.id === id)
+    .permissions.find((perm) => perm.level === level).functions
+})
+
+export const buildPermissionsFromIdsAndLevels = (tuples) =>
+  tuples.map((tuple) => tuple.map(getPermissionFunctionsFromIdAndLevel))

--- a/test/unit/integration/graphql/business.test.js
+++ b/test/unit/integration/graphql/business.test.js
@@ -578,7 +578,7 @@ describe('Query.business.customers', () => {
     })
   })
 
-  it('permissions', async () => {
+  it.skip('permissions', async () => {
     const personId = 5302028
     const result = await graphql({
       source: `#graphql

--- a/test/unit/integration/graphql/business.test.js
+++ b/test/unit/integration/graphql/business.test.js
@@ -578,7 +578,7 @@ describe('Query.business.customers', () => {
     })
   })
 
-  it.skip('permissions', async () => {
+  it('permissions', async () => {
     const personId = 5302028
     const result = await graphql({
       source: `#graphql
@@ -588,6 +588,7 @@ describe('Query.business.customers', () => {
               permissionGroups {
                 id
                 level
+                functions
               }
             }
           }

--- a/test/unit/integration/graphql/customer.test.js
+++ b/test/unit/integration/graphql/customer.test.js
@@ -8,6 +8,7 @@ import { transformAuthenticateQuestionsAnswers } from '../../../../app/transform
 import { ruralPaymentsPortalCustomerTransformer } from '../../../../app/transformers/rural-payments/customer.js'
 import { personById } from '../../../../mocks/fixtures/person.js'
 import mockServer from '../../../../mocks/server.js'
+import { buildPermissionsFromIdsAndLevels } from '../../../../test/test-helpers/permissions.js'
 import { fakeContext } from '../../../test-setup.js'
 
 const personFixture = personById({ id: '5007136' })
@@ -451,6 +452,7 @@ describe('Query.customer.business', () => {
               permissionGroups {
                 id
                 level
+                functions
               }
             }
           }
@@ -464,41 +466,23 @@ describe('Query.customer.business', () => {
       contextValue: fakeContext
     })
 
+    const [permissionGroups] = buildPermissionsFromIdsAndLevels([
+      [
+        { id: 'BASIC_PAYMENT_SCHEME', level: 'NO_ACCESS' },
+        { id: 'BUSINESS_DETAILS', level: 'AMEND' },
+        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
+        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
+        { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
+        { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+        { id: 'LAND_DETAILS', level: 'VIEW' }
+      ]
+    ])
     expect(result).toEqual({
       data: {
         customer: {
           business: {
             role: 'Employee',
-            permissionGroups: [
-              {
-                id: 'BASIC_PAYMENT_SCHEME',
-                level: 'NO_ACCESS'
-              },
-              {
-                id: 'BUSINESS_DETAILS',
-                level: 'AMEND'
-              },
-              {
-                id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS',
-                level: 'SUBMIT'
-              },
-              {
-                id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
-                level: 'SUBMIT'
-              },
-              {
-                id: 'ENTITLEMENTS',
-                level: 'NO_ACCESS'
-              },
-              {
-                id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS',
-                level: 'NO_ACCESS'
-              },
-              {
-                id: 'LAND_DETAILS',
-                level: 'VIEW'
-              }
-            ]
+            permissionGroups
           }
         }
       }

--- a/test/unit/integration/graphql/full-schema.gql
+++ b/test/unit/integration/graphql/full-schema.gql
@@ -841,6 +841,11 @@ type ActivePermissionGroup {
   The permission level customer has for the business.
   """
   level: PermissionLevel
+
+  """
+  The functions that can be performed with given permission level.
+  """
+  functions: [String]
 }
 
 type PermissionGroup {

--- a/test/unit/integration/graphql/partial-schema.gql
+++ b/test/unit/integration/graphql/partial-schema.gql
@@ -408,6 +408,11 @@ type ActivePermissionGroup {
   The permission level customer has for the business.
   """
   level: PermissionLevel
+
+  """
+  The functions that can be performed with given permission level.
+  """
+  functions: [String]
 }
 
 enum AuthRole {

--- a/test/unit/integration/graphql/permissions.test.js
+++ b/test/unit/integration/graphql/permissions.test.js
@@ -51,7 +51,9 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in View BPS',
+                  'View business summary',
+                  'View claims',
+                  'View land, features and covers',
                   'Create and edit a claim',
                   'Amend a previously submitted claim',
                   'Amend land, features and covers'
@@ -61,7 +63,12 @@ describe('Query.permissionGroups', () => {
               {
                 active: true,
                 functions: [
-                  'All permissions in Amend BPS',
+                  'View business summary',
+                  'View claims',
+                  'View land, features and covers',
+                  'Create and edit a claim',
+                  'Amend a previously submitted claim',
+                  'Amend land, features and covers',
                   'Submit a claim',
                   'Withdraw a claim',
                   'Receive warnings and notifications'
@@ -83,7 +90,8 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in View Business Details',
+                  'View business details',
+                  'View people associated with the business',
                   'Amend business and correspondence contact details'
                 ],
                 level: 'AMEND'
@@ -91,7 +99,9 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in Amend Business Details',
+                  'View business details',
+                  'View people associated with the business',
+                  'Amend business and correspondence contact details',
                   'Amend controlled information, such as business name',
                   'Confirm business details',
                   'Amend bank account details',
@@ -102,7 +112,13 @@ describe('Query.permissionGroups', () => {
               {
                 active: true,
                 functions: [
-                  'All permissions in Make Legal Changes Business Details',
+                  'View business details',
+                  'View people associated with the business',
+                  'Amend business and correspondence contact details',
+                  'Amend controlled information, such as business name',
+                  'Confirm business details',
+                  'Amend bank account details',
+                  'Make young/new farmer declaration',
                   'Add someone to the business',
                   'Give permissions on business'
                 ],
@@ -129,7 +145,11 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in View CS Agreements',
+                  'View CS Agreements',
+                  'View Land, Features and Cover',
+                  'View CS Agreement amendments',
+                  'View CS agreement Transfers',
+                  'View CS Claims',
                   'Amend land, Features and Covers',
                   'Create and edit a CS claim',
                   'Amend a previously submitted claim',
@@ -143,7 +163,18 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in Amend CS agreements',
+                  'View CS Agreements',
+                  'View Land, Features and Cover',
+                  'View CS Agreement amendments',
+                  'View CS agreement Transfers',
+                  'View CS Claims',
+                  'Amend land, Features and Covers',
+                  'Create and edit a CS claim',
+                  'Amend a previously submitted claim',
+                  'Create and edit a CS agreement Amendment',
+                  'Revise a previously submitted agreement amendment',
+                  'Create and Edit a CS agreement transfer',
+                  'Revise a previously submitted agreement transfer',
                   'Submit Acceptance of CS Agreement offer',
                   'Submit rejection of CS agreement offer',
                   'Submit (and resubmit) a CS claim',
@@ -176,7 +207,10 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in View CS Applications',
+                  'View CS Scheme eligibility',
+                  'View Applications',
+                  'View land, features and covers',
+                  'View CS agreement offer',
                   'View draft CS Agreements',
                   'Create and edit a CS application',
                   'Amend a previously submitted CS application',
@@ -187,7 +221,14 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in Amend CS permissions',
+                  'View CS Scheme eligibility',
+                  'View Applications',
+                  'View land, features and covers',
+                  'View CS agreement offer',
+                  'View draft CS Agreements',
+                  'Create and edit a CS application',
+                  'Amend a previously submitted CS application',
+                  'Amend Land, Features and Covers',
                   'Submit CS Application',
                   'Withdraw CS application',
                   'Receive warnings and notifications'
@@ -235,7 +276,10 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in View Environmental Land Management',
+                  'View Environmental Land Management scheme eligibility',
+                  'View Environmental Land Management applications',
+                  'View land, features and covers',
+                  'View Environmental Land Management agreement offer',
                   'View Environmental Land Management agreements',
                   'Create and edit a Environmental Land Management application',
                   'Amend (but not resubmit) a previously submitted Environmental Land Management application',
@@ -246,7 +290,14 @@ describe('Query.permissionGroups', () => {
               {
                 active: false,
                 functions: [
-                  'All permissions in Amend Environmental Land Management',
+                  'View Environmental Land Management scheme eligibility',
+                  'View Environmental Land Management applications',
+                  'View land, features and covers',
+                  'View Environmental Land Management agreement offer',
+                  'View Environmental Land Management agreements',
+                  'Create and edit a Environmental Land Management application',
+                  'Amend (but not resubmit) a previously submitted Environmental Land Management application',
+                  'Amend land, features and covers',
                   'Submit Environmental Land Management application',
                   'Withdraw Environmental Land Management application',
                   'Submit acceptance of Environmental Land Management agreement offer',

--- a/test/unit/resolvers/customer.test.js
+++ b/test/unit/resolvers/customer.test.js
@@ -7,6 +7,7 @@ import {
   organisationPersonSummary
 } from '../../../mocks/fixtures/organisation.js'
 import { personById } from '../../../mocks/fixtures/person.js'
+import { buildPermissionsFromIdsAndLevels } from '../../../test/test-helpers/permissions.js'
 
 const orgId = '5565448'
 const personId = '5007136'
@@ -225,15 +226,18 @@ describe('CustomerBusiness', () => {
       }
     )
 
-    expect(response).toEqual([
-      { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
-      { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
-      { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
-      { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
-      { id: 'ENTITLEMENTS', level: 'AMEND' },
-      { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
-      { id: 'LAND_DETAILS', level: 'AMEND' }
-    ])
+    const permissions = buildPermissionsFromIdsAndLevels([
+      [
+        { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
+        { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
+        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
+        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
+        { id: 'ENTITLEMENTS', level: 'AMEND' },
+        { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+        { id: 'LAND_DETAILS', level: 'AMEND' }
+      ]
+    ])[0]
+    expect(response).toEqual(permissions)
   })
 
   describe('CustomerBusiness.messages', () => {
@@ -305,14 +309,17 @@ describe('CustomerBusinessPermissionGroup', () => {
       { dataSources }
     )
 
-    expect(response).toEqual([
-      { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
-      { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
-      { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
-      { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
-      { id: 'ENTITLEMENTS', level: 'AMEND' },
-      { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
-      { id: 'LAND_DETAILS', level: 'AMEND' }
-    ])
+    const permissions = buildPermissionsFromIdsAndLevels([
+      [
+        { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
+        { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
+        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
+        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
+        { id: 'ENTITLEMENTS', level: 'AMEND' },
+        { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+        { id: 'LAND_DETAILS', level: 'AMEND' }
+      ]
+    ])[0]
+    expect(response).toEqual(permissions)
   })
 })

--- a/test/unit/transformers/rural-payments/business.test.js
+++ b/test/unit/transformers/rural-payments/business.test.js
@@ -4,6 +4,7 @@ import {
   transformOrganisationCustomers
 } from '../../../../app/transformers/rural-payments/business.js'
 import { organisationPeopleByOrgId } from '../../../../mocks/fixtures/organisation.js'
+import { buildPermissionsFromIdsAndLevels } from '../../../../test/test-helpers/permissions.js'
 
 describe('Business transformer', () => {
   test('#transformOrganisationCustomers', () => {
@@ -24,7 +25,7 @@ describe('Business transformer', () => {
   })
 
   const permissionGroups = new Permissions().getPermissionGroups()
-  const expectedPermissions = [
+  const expectedPermissions = buildPermissionsFromIdsAndLevels([
     [
       { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
       { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
@@ -65,14 +66,7 @@ describe('Business transformer', () => {
       { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
       { id: 'LAND_DETAILS', level: 'AMEND' }
     ]
-  ].map((customerPermissions) =>
-    customerPermissions.map((permission) => ({
-      ...permission,
-      functions: permissionGroups
-        .find((group) => group.id === permission.id)
-        .permissions.find((perm) => perm.level === permission.level).functions
-    }))
-  )
+  ])
 
   test('#transformBusinessCustomerPrivilegesToPermissionGroups', () => {
     const { _data: customers } = organisationPeopleByOrgId(5565448)

--- a/test/unit/transformers/rural-payments/business.test.js
+++ b/test/unit/transformers/rural-payments/business.test.js
@@ -23,8 +23,58 @@ describe('Business transformer', () => {
     expect(transformOrganisationCustomers(customers)).toEqual(transformedCustomers)
   })
 
+  const permissionGroups = new Permissions().getPermissionGroups()
+  const expectedPermissions = [
+    [
+      { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
+      { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
+      { id: 'ENTITLEMENTS', level: 'AMEND' },
+      { id: 'LAND_DETAILS', level: 'AMEND' }
+    ],
+    [
+      { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
+      { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
+      { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
+      { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
+      { id: 'ENTITLEMENTS', level: 'AMEND' },
+      { id: 'LAND_DETAILS', level: 'AMEND' }
+    ],
+    [
+      { id: 'BASIC_PAYMENT_SCHEME', level: 'AMEND' },
+      { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
+      { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
+      { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
+      { id: 'ENTITLEMENTS', level: 'AMEND' },
+      { id: 'LAND_DETAILS', level: 'AMEND' }
+    ],
+    [
+      { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
+      { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
+      { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
+      { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
+      { id: 'ENTITLEMENTS', level: 'AMEND' },
+      { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'SUBMIT' },
+      { id: 'LAND_DETAILS', level: 'AMEND' }
+    ],
+    [
+      { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
+      { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
+      { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
+      { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
+      { id: 'ENTITLEMENTS', level: 'AMEND' },
+      { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+      { id: 'LAND_DETAILS', level: 'AMEND' }
+    ]
+  ].map((customerPermissions) =>
+    customerPermissions.map((permission) => ({
+      ...permission,
+      functions: permissionGroups
+        .find((group) => group.id === permission.id)
+        .permissions.find((perm) => perm.level === permission.level).functions
+    }))
+  )
+
   test('#transformBusinessCustomerPrivilegesToPermissionGroups', () => {
-    const permissionGroups = new Permissions().getPermissionGroups()
     const { _data: customers } = organisationPeopleByOrgId(5565448)
 
     const transformedPermissionGroups = customers.map((customer) => {
@@ -34,53 +84,6 @@ describe('Business transformer', () => {
       )
     })
 
-    expect(transformedPermissionGroups).toEqual([
-      [
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
-        { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
-        { id: 'ENTITLEMENTS', level: 'AMEND' },
-        { id: 'LAND_DETAILS', level: 'AMEND' }
-      ],
-      [
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
-        { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
-        { id: 'ENTITLEMENTS', level: 'AMEND' },
-        { id: 'LAND_DETAILS', level: 'AMEND' }
-      ],
-      [
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'AMEND' },
-        { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
-        { id: 'ENTITLEMENTS', level: 'AMEND' },
-        { id: 'LAND_DETAILS', level: 'AMEND' }
-      ],
-      [
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
-        { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
-        { id: 'ENTITLEMENTS', level: 'AMEND' },
-        {
-          id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS',
-          level: 'SUBMIT'
-        },
-        { id: 'LAND_DETAILS', level: 'AMEND' }
-      ],
-      [
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'SUBMIT' },
-        { id: 'BUSINESS_DETAILS', level: 'FULL_PERMISSION' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'SUBMIT' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'SUBMIT' },
-        { id: 'ENTITLEMENTS', level: 'AMEND' },
-        {
-          id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS',
-          level: 'NO_ACCESS'
-        },
-        { id: 'LAND_DETAILS', level: 'AMEND' }
-      ]
-    ])
+    expect(transformedPermissionGroups).toEqual(expectedPermissions)
   })
 })

--- a/test/unit/transformers/rural-payments/customer.test.js
+++ b/test/unit/transformers/rural-payments/customer.test.js
@@ -8,6 +8,10 @@ import {
   organisationPeopleByOrgId,
   organisationPersonSummary
 } from '../../../../mocks/fixtures/organisation.js'
+import {
+  buildPermissionsFromIdsAndLevels,
+  getPermissionFunctionsFromIdAndLevel
+} from '../../../../test/test-helpers/permissions.js'
 
 describe('Customer transformer', () => {
   test('#transformBusinessCustomerToCustomerRole', () => {
@@ -55,15 +59,18 @@ describe('Customer transformer', () => {
         permissionGroups
       )
 
-      expect(transformedPermissionGroups).toEqual([
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'NO_ACCESS' },
-        { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
-        { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+      const [permissions] = buildPermissionsFromIdsAndLevels([
+        [
+          { id: 'BASIC_PAYMENT_SCHEME', level: 'NO_ACCESS' },
+          { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
+          { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+        ]
       ])
+      expect(transformedPermissionGroups).toEqual(permissions)
     })
 
     test('should fail with NO_ACCESS if customers with no privileges', () => {
@@ -73,15 +80,18 @@ describe('Customer transformer', () => {
         permissionGroups
       )
 
-      expect(transformedPermissionGroups).toEqual([
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'NO_ACCESS' },
-        { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
-        { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+      const [permissions] = buildPermissionsFromIdsAndLevels([
+        [
+          { id: 'BASIC_PAYMENT_SCHEME', level: 'NO_ACCESS' },
+          { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
+          { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+        ]
       ])
+      expect(transformedPermissionGroups).toEqual(permissions)
     })
 
     test('should return correct privilege', () => {
@@ -91,15 +101,18 @@ describe('Customer transformer', () => {
         permissionGroups
       )
 
-      expect(transformedPermissionGroups).toEqual([
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'VIEW' },
-        { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
-        { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+      const [permissions] = buildPermissionsFromIdsAndLevels([
+        [
+          { id: 'BASIC_PAYMENT_SCHEME', level: 'VIEW' },
+          { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
+          { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+        ]
       ])
+      expect(transformedPermissionGroups).toEqual(permissions)
     })
 
     test('should return highest privilege when two in same group', () => {
@@ -116,15 +129,18 @@ describe('Customer transformer', () => {
         permissionGroups
       )
 
-      expect(transformedPermissionGroups).toEqual([
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'AMEND' },
-        { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
-        { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+      const [permissions] = buildPermissionsFromIdsAndLevels([
+        [
+          { id: 'BASIC_PAYMENT_SCHEME', level: 'AMEND' },
+          { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
+          { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+        ]
       ])
+      expect(transformedPermissionGroups).toEqual(permissions)
     })
 
     test('should be case insensitive', () => {
@@ -136,15 +152,18 @@ describe('Customer transformer', () => {
         permissionGroups
       )
 
-      expect(transformedPermissionGroups).toEqual([
-        { id: 'BASIC_PAYMENT_SCHEME', level: 'AMEND' },
-        { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
-        { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
-        { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
-        { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+      const [permissions] = buildPermissionsFromIdsAndLevels([
+        [
+          { id: 'BASIC_PAYMENT_SCHEME', level: 'AMEND' },
+          { id: 'BUSINESS_DETAILS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS', level: 'NO_ACCESS' },
+          { id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'ENTITLEMENTS', level: 'NO_ACCESS' },
+          { id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS', level: 'NO_ACCESS' },
+          { id: 'LAND_DETAILS', level: 'NO_ACCESS' }
+        ]
       ])
+      expect(transformedPermissionGroups).toEqual(permissions)
     })
 
     const cases = [
@@ -218,7 +237,7 @@ describe('Customer transformer', () => {
             [{ customerReference: 'crn', privileges: [privilegeName] }],
             permissionGroups
           )
-        ).toContainEqual(expectedResult)
+        ).toContainEqual(getPermissionFunctionsFromIdAndLevel(expectedResult))
       }
     )
 

--- a/test/unit/transformers/rural-payments/permissions.test.js
+++ b/test/unit/transformers/rural-payments/permissions.test.js
@@ -1,8 +1,4 @@
-import { Permissions } from '../../../../app/data-sources/static/permissions.js'
-import {
-  transformOrganisationAuthorisationToCustomerBusinessPermissionLevel,
-  transformPrivilegesListToBusinessCustomerPermissions
-} from '../../../../app/transformers/rural-payments/permissions.js'
+import { transformOrganisationAuthorisationToCustomerBusinessPermissionLevel } from '../../../../app/transformers/rural-payments/permissions.js'
 import { organisationPeopleByOrgId } from '../../../../mocks/fixtures/organisation.js'
 
 const orgId = '5565448'
@@ -30,41 +26,5 @@ describe('Permissions transformer', () => {
       orgCustomers
     )
     expect(result).toEqual('MOCK_LEVEL')
-  })
-
-  test('returns active permissions', () => {
-    const result = transformPrivilegesListToBusinessCustomerPermissions(
-      organisationPeopleByOrgId('5565448')._data[0].privileges,
-      new Permissions().getPermissionGroups()
-    )
-    expect(result).toEqual([
-      {
-        id: 'BASIC_PAYMENT_SCHEME',
-        level: 'SUBMIT',
-        name: 'Basic payment scheme (BPS)'
-      },
-      {
-        id: 'BUSINESS_DETAILS',
-        level: 'FULL_PERMISSION',
-        name: 'Business details'
-      },
-      {
-        id: 'COUNTRYSIDE_STEWARDSHIP_AGREEMENTS',
-        level: 'NO_ACCESS',
-        name: 'Countryside Stewardship (Agreements)'
-      },
-      {
-        id: 'COUNTRYSIDE_STEWARDSHIP_APPLICATIONS',
-        level: 'NO_ACCESS',
-        name: 'Countryside Stewardship (Applications)'
-      },
-      { id: 'ENTITLEMENTS', level: 'AMEND', name: 'Entitlements' },
-      {
-        id: 'ENVIRONMENTAL_LAND_MANAGEMENT_APPLICATIONS',
-        level: 'NO_ACCESS',
-        name: 'Environmental Land Management (Applications)'
-      },
-      { id: 'LAND_DETAILS', level: 'AMEND', name: 'Land details' }
-    ])
   })
 })


### PR DESCRIPTION
Add `functions` to the list of allowed fields for permissions queries.
This detail can then be used to provide helpful descriptions, that define what actions specific permissions enable customers to perform.